### PR TITLE
Add info callout on `playground` directory

### DIFF
--- a/exercises/01.e2e/01.problem.playwright/README.mdx
+++ b/exercises/01.e2e/01.problem.playwright/README.mdx
@@ -32,7 +32,13 @@ in <InlineFile file="playwright.config.ts" />. If you want to learn more about
 the configuration options, knock yourself out with
 [this reference](https://playwright.dev/docs/test-configuration).
 
-To start running the test, open up a terminal in the playground directory and
+<callout-info>
+	Playwright-specific commands must be run in `playground` directory. If
+	you're currently in the workshop's root directory, simply run `cd playground`
+	to get there.
+</callout-info>
+
+To start running the test, open up a terminal in the `playground` directory and
 run:
 
 ```sh nonumber


### PR DESCRIPTION
This callout might make it clearer for users to avoid trying to run `npx playwright` commands from within the root directory, which does not work.