### PR TITLE
Small update to exercise command

### DIFF
--- a/exercises/08.http-mocking/01.problem.start-server/README.mdx
+++ b/exercises/08.http-mocking/01.problem.start-server/README.mdx
@@ -26,5 +26,5 @@ you that does the conversion for you. You'll find it at the bottom of the test
 file. It's called `convertSetCookieToCookie`.
 
 ```sh nonumber
-npx vitest auth.github
+npx vitest auth.$provider
 ```

--- a/exercises/08.http-mocking/01.problem.start-server/README.mdx
+++ b/exercises/08.http-mocking/01.problem.start-server/README.mdx
@@ -26,5 +26,5 @@ you that does the conversion for you. You'll find it at the bottom of the test
 file. It's called `convertSetCookieToCookie`.
 
 ```sh nonumber
-npx vitest auth.$provider
+npx vitest auth.\$provider
 ```


### PR DESCRIPTION
`npx vitest auth.github` won't run because it won't find files under that name since the relevant file is `auth.$provider.callback.test.ts`.

What it is right now:
<img width="710" alt="image" src="https://github.com/epicweb-dev/full-stack-testing/assets/47903279/a79affa1-0c9f-488f-baee-7e54a384c371">

Error message:
```
> npx vitest auth.github

 DEV  v0.34.6 /repos/epicweb-dev/full-stack-testing/playground

filter:  auth.github
include: ./app/**/*.test.{ts,tsx}
exclude:  **/node_modules/**, **/dist/**, **/cypress/**, **/.{idea,git,cache,output,temp}/**, **/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*
watch exclude:  **/node_modules/**, **/dist/**

No test files found, exiting with code 1
```