### PR TITLE
Fix fixtures directory typo

### DIFF
--- a/exercises/02.e2e-mocking/01.problem.write-email/README.mdx
+++ b/exercises/02.e2e-mocking/01.problem.write-email/README.mdx
@@ -14,7 +14,7 @@ in the next step, you can use that file to read the email and get the
 verification link.
 
 You'll know it's working when you've run the test, and even though it's not
-passing yet, you should get a new JSON file in `tests/fixtures/emails` for the
+passing yet, you should get a new JSON file in `tests/fixtures/email` for the
 email that was sent.
 
 ```sh nonumber


### PR DESCRIPTION
The file directory referenced in the readme for this exercise is supposed to be tests/fixtures/email not  tests/fixtures/emails