### PR TITLE
--chore: fix the same typo across multiple files

### DIFF
--- a/exercises/01.e2e/01.problem.playwright/app/utils/env.server.ts
+++ b/exercises/01.e2e/01.problem.playwright/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/01.e2e/01.solution.playwright/app/utils/env.server.ts
+++ b/exercises/01.e2e/01.solution.playwright/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/01.e2e/02.problem.insert-user/app/utils/env.server.ts
+++ b/exercises/01.e2e/02.problem.insert-user/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/01.e2e/02.solution.insert-user/app/utils/env.server.ts
+++ b/exercises/01.e2e/02.solution.insert-user/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/01.e2e/03.problem.cleanup/app/utils/env.server.ts
+++ b/exercises/01.e2e/03.problem.cleanup/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/01.e2e/03.solution.cleanup/app/utils/env.server.ts
+++ b/exercises/01.e2e/03.solution.cleanup/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/01.e2e/04.problem.fixtures/app/utils/env.server.ts
+++ b/exercises/01.e2e/04.problem.fixtures/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/01.e2e/04.solution.fixtures/app/utils/env.server.ts
+++ b/exercises/01.e2e/04.solution.fixtures/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/02.e2e-mocking/01.problem.write-email/app/utils/env.server.ts
+++ b/exercises/02.e2e-mocking/01.problem.write-email/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/02.e2e-mocking/01.solution.write-email/app/utils/env.server.ts
+++ b/exercises/02.e2e-mocking/01.solution.write-email/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/02.e2e-mocking/02.problem.read-email/app/utils/env.server.ts
+++ b/exercises/02.e2e-mocking/02.problem.read-email/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/02.e2e-mocking/02.solution.read-email/app/utils/env.server.ts
+++ b/exercises/02.e2e-mocking/02.solution.read-email/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/03.authenticated-e2e/01.problem.login/app/utils/env.server.ts
+++ b/exercises/03.authenticated-e2e/01.problem.login/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/03.authenticated-e2e/01.solution.login/app/utils/env.server.ts
+++ b/exercises/03.authenticated-e2e/01.solution.login/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/04.unit-test/01.problem.init/app/utils/env.server.ts
+++ b/exercises/04.unit-test/01.problem.init/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/04.unit-test/01.solution.init/app/utils/env.server.ts
+++ b/exercises/04.unit-test/01.solution.init/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/04.unit-test/02.problem.spies/app/utils/env.server.ts
+++ b/exercises/04.unit-test/02.problem.spies/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/04.unit-test/02.solution.spies/app/utils/env.server.ts
+++ b/exercises/04.unit-test/02.solution.spies/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/04.unit-test/03.problem.hooks/app/utils/env.server.ts
+++ b/exercises/04.unit-test/03.problem.hooks/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/04.unit-test/03.solution.hooks/app/utils/env.server.ts
+++ b/exercises/04.unit-test/03.solution.hooks/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/04.unit-test/04.problem.setup/app/utils/env.server.ts
+++ b/exercises/04.unit-test/04.problem.setup/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/04.unit-test/04.solution.setup/app/utils/env.server.ts
+++ b/exercises/04.unit-test/04.solution.setup/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/05.component-test/01.problem.init/app/utils/env.server.ts
+++ b/exercises/05.component-test/01.problem.init/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/05.component-test/01.solution.init/app/utils/env.server.ts
+++ b/exercises/05.component-test/01.solution.init/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/05.component-test/02.problem.cleanup/app/utils/env.server.ts
+++ b/exercises/05.component-test/02.problem.cleanup/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/05.component-test/02.solution.cleanup/app/utils/env.server.ts
+++ b/exercises/05.component-test/02.solution.cleanup/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/06.hooks/01.problem.render-hook/app/utils/env.server.ts
+++ b/exercises/06.hooks/01.problem.render-hook/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/06.hooks/01.solution.render-hook/app/utils/env.server.ts
+++ b/exercises/06.hooks/01.solution.render-hook/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/06.hooks/02.problem.test-component/app/utils/env.server.ts
+++ b/exercises/06.hooks/02.problem.test-component/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/06.hooks/02.solution.test-component/app/utils/env.server.ts
+++ b/exercises/06.hooks/02.solution.test-component/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/07.remix-component/01.problem.stub-remix/app/utils/env.server.ts
+++ b/exercises/07.remix-component/01.problem.stub-remix/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/07.remix-component/01.solution.stub-remix/app/utils/env.server.ts
+++ b/exercises/07.remix-component/01.solution.stub-remix/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/07.remix-component/02.problem.multiple-routes/app/utils/env.server.ts
+++ b/exercises/07.remix-component/02.problem.multiple-routes/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/07.remix-component/02.solution.multiple-routes/app/utils/env.server.ts
+++ b/exercises/07.remix-component/02.solution.multiple-routes/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/08.http-mocking/01.problem.start-server/app/utils/env.server.ts
+++ b/exercises/08.http-mocking/01.problem.start-server/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/08.http-mocking/01.solution.start-server/app/utils/env.server.ts
+++ b/exercises/08.http-mocking/01.solution.start-server/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/08.http-mocking/02.problem.override-mocks/app/utils/env.server.ts
+++ b/exercises/08.http-mocking/02.problem.override-mocks/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/08.http-mocking/02.solution.override-mocks/app/utils/env.server.ts
+++ b/exercises/08.http-mocking/02.solution.override-mocks/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/08.http-mocking/03.problem.setup/app/utils/env.server.ts
+++ b/exercises/08.http-mocking/03.problem.setup/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/08.http-mocking/03.solution.setup/app/utils/env.server.ts
+++ b/exercises/08.http-mocking/03.solution.setup/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/09.authenticated-integration/01.problem.create-session/app/utils/env.server.ts
+++ b/exercises/09.authenticated-integration/01.problem.create-session/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/09.authenticated-integration/01.solution.create-session/app/utils/env.server.ts
+++ b/exercises/09.authenticated-integration/01.solution.create-session/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/09.authenticated-integration/02.problem.assert/app/utils/env.server.ts
+++ b/exercises/09.authenticated-integration/02.problem.assert/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/09.authenticated-integration/02.solution.assert/app/utils/env.server.ts
+++ b/exercises/09.authenticated-integration/02.solution.assert/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/09.authenticated-integration/03.problem.routes/app/utils/env.server.ts
+++ b/exercises/09.authenticated-integration/03.problem.routes/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/09.authenticated-integration/03.solution.routes/app/utils/env.server.ts
+++ b/exercises/09.authenticated-integration/03.solution.routes/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/10.custom-assertions/01.problem.location/app/utils/env.server.ts
+++ b/exercises/10.custom-assertions/01.problem.location/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/10.custom-assertions/01.solution.location/app/utils/env.server.ts
+++ b/exercises/10.custom-assertions/01.solution.location/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/11.test-db/01.problem.setup/app/utils/env.server.ts
+++ b/exercises/11.test-db/01.problem.setup/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/11.test-db/01.solution.setup/app/utils/env.server.ts
+++ b/exercises/11.test-db/01.solution.setup/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/11.test-db/02.problem.isolated-db/app/utils/env.server.ts
+++ b/exercises/11.test-db/02.problem.isolated-db/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/11.test-db/02.solution.isolated-db/app/utils/env.server.ts
+++ b/exercises/11.test-db/02.solution.isolated-db/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/11.test-db/03.problem.global-setup/app/utils/env.server.ts
+++ b/exercises/11.test-db/03.problem.global-setup/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 

--- a/exercises/11.test-db/03.solution.global-setup/app/utils/env.server.ts
+++ b/exercises/11.test-db/03.solution.global-setup/app/utils/env.server.ts
@@ -25,7 +25,7 @@ export function init() {
 			parsed.error.flatten().fieldErrors,
 		)
 
-		throw new Error('Invalid envirmonment variables')
+		throw new Error('Invalid environment variables')
 	}
 }
 


### PR DESCRIPTION
The word "environment" is misspelt across several files in the repo. 
This PR corrects them all 