### PR TITLE
Update filename for example code snippets in "Testing Remix: Intro"

### DIFF
--- a/exercises/07.remix-component/README.mdx
+++ b/exercises/07.remix-component/README.mdx
@@ -13,7 +13,7 @@ So, the Remix team is working on a great solution for this called
 `createRemixStub` which allows you to create a mini-Remix app that you can
 render in your test and have all the routes you need for testing the component:
 
-```tsx filename=app/routes/counter.test.tsx
+```tsx filename=app/routes/counter.tsx
 import { useLoaderData } from '@remix-run/react'
 import { db } from '#app/utils/db.server'
 
@@ -36,7 +36,7 @@ export default function Counter() {
 }
 ```
 
-```tsx filename=app/counter.test.tsx
+```tsx filename=app/routes/counter.test.tsx
 import * as React from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -70,7 +70,7 @@ logic, however, I'm often interested in testing the component holistically, so
 we can actually import and use the original `action` and `loader` from the route
 as well:
 
-```tsx filename=app/counter.test.tsx
+```tsx filename=app/routes/counter.test.tsx
 import * as React from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'


### PR DESCRIPTION
Based on the `Counter` component import statement in the `.test.tsx` file, I believe the example filenames need to be updated to reflect their role and relation.

<img width="1000" alt="Screenshot 2025-04-12 at 1 31 51 PM" src="https://github.com/user-attachments/assets/d091b734-fdae-4201-abff-68732b976ce0" />
