### PR TITLE
fix: correct spelling of "abandoned" in altText for note images 

### DIFF
--- a/exercises/01.e2e/01.problem.playwright/tests/db-utils.ts
+++ b/exercises/01.e2e/01.problem.playwright/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/01.e2e/01.solution.playwright/tests/db-utils.ts
+++ b/exercises/01.e2e/01.solution.playwright/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/01.e2e/02.problem.insert-user/tests/db-utils.ts
+++ b/exercises/01.e2e/02.problem.insert-user/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/01.e2e/02.solution.insert-user/tests/db-utils.ts
+++ b/exercises/01.e2e/02.solution.insert-user/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/01.e2e/03.problem.cleanup/tests/db-utils.ts
+++ b/exercises/01.e2e/03.problem.cleanup/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/01.e2e/03.solution.cleanup/tests/db-utils.ts
+++ b/exercises/01.e2e/03.solution.cleanup/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/01.e2e/04.problem.fixtures/tests/db-utils.ts
+++ b/exercises/01.e2e/04.problem.fixtures/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/01.e2e/04.solution.fixtures/tests/db-utils.ts
+++ b/exercises/01.e2e/04.solution.fixtures/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/02.e2e-mocking/01.problem.write-email/tests/db-utils.ts
+++ b/exercises/02.e2e-mocking/01.problem.write-email/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/02.e2e-mocking/01.solution.write-email/tests/db-utils.ts
+++ b/exercises/02.e2e-mocking/01.solution.write-email/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/02.e2e-mocking/02.problem.read-email/tests/db-utils.ts
+++ b/exercises/02.e2e-mocking/02.problem.read-email/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/02.e2e-mocking/02.solution.read-email/tests/db-utils.ts
+++ b/exercises/02.e2e-mocking/02.solution.read-email/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/03.authenticated-e2e/01.problem.login/tests/db-utils.ts
+++ b/exercises/03.authenticated-e2e/01.problem.login/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/03.authenticated-e2e/01.solution.login/tests/db-utils.ts
+++ b/exercises/03.authenticated-e2e/01.solution.login/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/04.unit-test/01.problem.init/tests/db-utils.ts
+++ b/exercises/04.unit-test/01.problem.init/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/04.unit-test/01.solution.init/tests/db-utils.ts
+++ b/exercises/04.unit-test/01.solution.init/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/04.unit-test/02.problem.spies/tests/db-utils.ts
+++ b/exercises/04.unit-test/02.problem.spies/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/04.unit-test/02.solution.spies/tests/db-utils.ts
+++ b/exercises/04.unit-test/02.solution.spies/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/04.unit-test/03.problem.hooks/tests/db-utils.ts
+++ b/exercises/04.unit-test/03.problem.hooks/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/04.unit-test/03.solution.hooks/tests/db-utils.ts
+++ b/exercises/04.unit-test/03.solution.hooks/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/04.unit-test/04.problem.setup/tests/db-utils.ts
+++ b/exercises/04.unit-test/04.problem.setup/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/04.unit-test/04.solution.setup/tests/db-utils.ts
+++ b/exercises/04.unit-test/04.solution.setup/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/05.component-test/01.problem.init/tests/db-utils.ts
+++ b/exercises/05.component-test/01.problem.init/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/05.component-test/01.solution.init/tests/db-utils.ts
+++ b/exercises/05.component-test/01.solution.init/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/05.component-test/02.problem.cleanup/tests/db-utils.ts
+++ b/exercises/05.component-test/02.problem.cleanup/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/05.component-test/02.solution.cleanup/tests/db-utils.ts
+++ b/exercises/05.component-test/02.solution.cleanup/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/06.hooks/01.problem.render-hook/tests/db-utils.ts
+++ b/exercises/06.hooks/01.problem.render-hook/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/06.hooks/01.solution.render-hook/tests/db-utils.ts
+++ b/exercises/06.hooks/01.solution.render-hook/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/06.hooks/02.problem.test-component/tests/db-utils.ts
+++ b/exercises/06.hooks/02.problem.test-component/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/06.hooks/02.solution.test-component/tests/db-utils.ts
+++ b/exercises/06.hooks/02.solution.test-component/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/07.remix-component/01.problem.stub-remix/tests/db-utils.ts
+++ b/exercises/07.remix-component/01.problem.stub-remix/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/07.remix-component/01.solution.stub-remix/tests/db-utils.ts
+++ b/exercises/07.remix-component/01.solution.stub-remix/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/07.remix-component/02.problem.multiple-routes/tests/db-utils.ts
+++ b/exercises/07.remix-component/02.problem.multiple-routes/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/07.remix-component/02.solution.multiple-routes/tests/db-utils.ts
+++ b/exercises/07.remix-component/02.solution.multiple-routes/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/08.http-mocking/01.problem.start-server/tests/db-utils.ts
+++ b/exercises/08.http-mocking/01.problem.start-server/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/08.http-mocking/01.solution.start-server/tests/db-utils.ts
+++ b/exercises/08.http-mocking/01.solution.start-server/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/08.http-mocking/02.problem.override-mocks/tests/db-utils.ts
+++ b/exercises/08.http-mocking/02.problem.override-mocks/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/08.http-mocking/02.solution.override-mocks/tests/db-utils.ts
+++ b/exercises/08.http-mocking/02.solution.override-mocks/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/08.http-mocking/03.problem.setup/tests/db-utils.ts
+++ b/exercises/08.http-mocking/03.problem.setup/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/08.http-mocking/03.solution.setup/tests/db-utils.ts
+++ b/exercises/08.http-mocking/03.solution.setup/tests/db-utils.ts
@@ -67,7 +67,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/09.authenticated-integration/01.problem.create-session/tests/db-utils.ts
+++ b/exercises/09.authenticated-integration/01.problem.create-session/tests/db-utils.ts
@@ -69,7 +69,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/09.authenticated-integration/01.solution.create-session/tests/db-utils.ts
+++ b/exercises/09.authenticated-integration/01.solution.create-session/tests/db-utils.ts
@@ -69,7 +69,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/09.authenticated-integration/02.problem.assert/tests/db-utils.ts
+++ b/exercises/09.authenticated-integration/02.problem.assert/tests/db-utils.ts
@@ -69,7 +69,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/09.authenticated-integration/02.solution.assert/tests/db-utils.ts
+++ b/exercises/09.authenticated-integration/02.solution.assert/tests/db-utils.ts
@@ -69,7 +69,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/09.authenticated-integration/03.problem.routes/tests/db-utils.ts
+++ b/exercises/09.authenticated-integration/03.problem.routes/tests/db-utils.ts
@@ -69,7 +69,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/09.authenticated-integration/03.solution.routes/tests/db-utils.ts
+++ b/exercises/09.authenticated-integration/03.solution.routes/tests/db-utils.ts
@@ -69,7 +69,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/10.custom-assertions/01.problem.location/tests/db-utils.ts
+++ b/exercises/10.custom-assertions/01.problem.location/tests/db-utils.ts
@@ -69,7 +69,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/10.custom-assertions/01.solution.location/tests/db-utils.ts
+++ b/exercises/10.custom-assertions/01.solution.location/tests/db-utils.ts
@@ -69,7 +69,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/11.test-db/01.problem.setup/tests/db-utils.ts
+++ b/exercises/11.test-db/01.problem.setup/tests/db-utils.ts
@@ -69,7 +69,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/11.test-db/01.solution.setup/tests/db-utils.ts
+++ b/exercises/11.test-db/01.solution.setup/tests/db-utils.ts
@@ -69,7 +69,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/11.test-db/02.problem.isolated-db/tests/db-utils.ts
+++ b/exercises/11.test-db/02.problem.isolated-db/tests/db-utils.ts
@@ -69,7 +69,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/11.test-db/02.solution.isolated-db/tests/db-utils.ts
+++ b/exercises/11.test-db/02.solution.isolated-db/tests/db-utils.ts
@@ -69,7 +69,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/11.test-db/03.problem.global-setup/tests/db-utils.ts
+++ b/exercises/11.test-db/03.problem.global-setup/tests/db-utils.ts
@@ -69,7 +69,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({

--- a/exercises/11.test-db/03.solution.global-setup/tests/db-utils.ts
+++ b/exercises/11.test-db/03.solution.global-setup/tests/db-utils.ts
@@ -69,7 +69,7 @@ export async function getNoteImages() {
 		}),
 		img({
 			altText:
-				'an office full of laptops and other office equipment that look like it was abandond in a rush out of the building in an emergency years ago.',
+				'an office full of laptops and other office equipment that look like it was abandoned in a rush out of the building in an emergency years ago.',
 			filepath: './tests/fixtures/images/notes/6.png',
 		}),
 		img({


### PR DESCRIPTION
Corrects the spelling of “abandoned” in the altText for note images across multiple test files to ensure consistency and clarity in alternative text.